### PR TITLE
deprecates DOMSubtreeModified event & refine

### DIFF
--- a/amazon-sponsored-items-blocker.user.js
+++ b/amazon-sponsored-items-blocker.user.js
@@ -25,16 +25,18 @@ setInterval(removeSponsoredAds, 200);
 console.log("amazon-sponsored-items-blocker loaded");
 
 function removeSponsoredAds() {
-  if (pageContentChanged) {
-    const ads = $(".celwidget").has(".s-sponsored-label-info-icon");
-    ads.each(function (_i, elem) {
-      // console.log("Object " + i + " contains an ad");
-      // $(this).css('background-color', 'red');
-      elem.remove();
-    });
-    console.log(
-      "amazon-sponsored-items-blocker: " + ads.length + " ads removed!"
-    );
-    pageContentChanged = false;
+  // guard
+  if (!pageContentChanged) {
+    return;
   }
+  const ads = $(".celwidget").has(".s-sponsored-label-info-icon");
+  ads.each(function (_i, elem) {
+    // console.log("Object " + i + " contains an ad");
+    // $(this).css('background-color', 'red');
+    elem.remove();
+  });
+  console.log(
+    "amazon-sponsored-items-blocker: " + ads.length + " ads removed!"
+  );
+  pageContentChanged = false;
 }

--- a/amazon-sponsored-items-blocker.user.js
+++ b/amazon-sponsored-items-blocker.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Amazon sponsored items blocker
 // @namespace    https://github.com/Stefan-Code/amazon-sponsored-items-blocker
-// @version      0.1
+// @version      0.2.0
 // @description  Blocks sponsored search results on amazon.com, amazon.co.uk and amazon.de
 // @author       Stefan-Code
 // @include      *://www.amazon.de/*

--- a/amazon-sponsored-items-blocker.user.js
+++ b/amazon-sponsored-items-blocker.user.js
@@ -29,10 +29,10 @@ function removeSponsoredAds() {
   if (!pageContentChanged) {
     return;
   }
-  const ads = $(".celwidget").has(".s-sponsored-label-info-icon");
-  ads.each(function (_i, elem) {
+  const ads = $(".AdHolder").has(".s-sponsored-label-info-icon");
+  ads.each(function (i, elem) {
     // console.log("Object " + i + " contains an ad");
-    // $(this).css('background-color', 'red');
+    // $(elem).css("background-color", "red");
     elem.remove();
   });
   console.log(

--- a/amazon-sponsored-items-blocker.user.js
+++ b/amazon-sponsored-items-blocker.user.js
@@ -13,9 +13,9 @@
 // @run-at document-end
 // ==/UserScript==
 $ = jQuery.noConflict(true);
-let pageContentchanged = false;
+let pageContentChanged = false;
 const observer = new MutationObserver(() => {
-  pageContentchanged = true;
+  pageContentChanged = true;
 });
 observer.observe(document.body, {
   childList: true,
@@ -25,7 +25,7 @@ setInterval(removeSponsoredAds, 200);
 console.log("amazon-sponsored-items-blocker loaded");
 
 function removeSponsoredAds() {
-  if (pageContentchanged) {
+  if (pageContentChanged) {
     let count = 0;
     $(".celwidget").each(function (i, obj) {
       if ($(this).find(".s-sponsored-label-info-icon").length > 0) {
@@ -36,6 +36,6 @@ function removeSponsoredAds() {
       }
     });
     console.log("amazon-sponsored-items-blocker: " + count + " ads removed!");
-    pageContentchanged = false;
+    pageContentChanged = false;
   }
 }

--- a/amazon-sponsored-items-blocker.user.js
+++ b/amazon-sponsored-items-blocker.user.js
@@ -27,7 +27,7 @@ console.log("amazon-sponsored-items-blocker loaded");
 function removeSponsoredAds() {
   if (pageContentChanged) {
     let count = 0;
-    $(".celwidget").each(function (i, obj) {
+    $(".celwidget").each(function (_i) {
       if ($(this).find(".s-sponsored-label-info-icon").length > 0) {
         //console.log("Object " + i + " contains an ad");
         //$(this).css('background-color', 'red');

--- a/amazon-sponsored-items-blocker.user.js
+++ b/amazon-sponsored-items-blocker.user.js
@@ -29,7 +29,7 @@ function removeSponsoredAds() {
   if (!pageContentChanged) {
     return;
   }
-  const ads = $(".AdHolder").has(".s-sponsored-label-info-icon");
+  const ads = $(".AdHolder");
   ads.each(function (i, elem) {
     // console.log("Object " + i + " contains an ad");
     // $(elem).css("background-color", "red");

--- a/amazon-sponsored-items-blocker.user.js
+++ b/amazon-sponsored-items-blocker.user.js
@@ -26,16 +26,15 @@ console.log("amazon-sponsored-items-blocker loaded");
 
 function removeSponsoredAds() {
   if (pageContentChanged) {
-    let count = 0;
-    $(".celwidget").each(function (_i) {
-      if ($(this).find(".s-sponsored-label-info-icon").length > 0) {
-        //console.log("Object " + i + " contains an ad");
-        //$(this).css('background-color', 'red');
-        this.remove();
-        count++;
-      }
+    const ads = $(".celwidget").has(".s-sponsored-label-info-icon");
+    ads.each(function (_i, elem) {
+      // console.log("Object " + i + " contains an ad");
+      // $(this).css('background-color', 'red');
+      elem.remove();
     });
-    console.log("amazon-sponsored-items-blocker: " + count + " ads removed!");
+    console.log(
+      "amazon-sponsored-items-blocker: " + ads.length + " ads removed!"
+    );
     pageContentChanged = false;
   }
 }

--- a/amazon-sponsored-items-blocker.user.js
+++ b/amazon-sponsored-items-blocker.user.js
@@ -13,25 +13,25 @@
 // @run-at document-end
 // ==/UserScript==
 $ = jQuery.noConflict(true);
-var pageContentchanged = false;
-$('body').bind("DOMSubtreeModified", function() {
-    pageContentchanged = true;
+let pageContentchanged = false;
+$("body").bind("DOMSubtreeModified", function () {
+  pageContentchanged = true;
 });
 setInterval(removeSponsoredAds, 200);
 console.log("amazon-sponsored-items-blocker loaded");
 
 function removeSponsoredAds() {
-    if (pageContentchanged) {
-        var count = 0;
-        $('.celwidget').each(function(i, obj) {
-            if ($(this).find(".s-sponsored-label-info-icon").length > 0) {
-                //console.log("Object " + i + " contains an ad");
-                //$(this).css('background-color', 'red');
-                (this).remove();
-                count++;
-            }
-        });
-        console.log("amazon-sponsored-items-blocker: " + count + " ads removed!");
-        pageContentchanged = false;
-    }
+  if (pageContentchanged) {
+    let count = 0;
+    $(".celwidget").each(function (i, obj) {
+      if ($(this).find(".s-sponsored-label-info-icon").length > 0) {
+        //console.log("Object " + i + " contains an ad");
+        //$(this).css('background-color', 'red');
+        this.remove();
+        count++;
+      }
+    });
+    console.log("amazon-sponsored-items-blocker: " + count + " ads removed!");
+    pageContentchanged = false;
+  }
 }

--- a/amazon-sponsored-items-blocker.user.js
+++ b/amazon-sponsored-items-blocker.user.js
@@ -14,8 +14,12 @@
 // ==/UserScript==
 $ = jQuery.noConflict(true);
 let pageContentchanged = false;
-$("body").bind("DOMSubtreeModified", function () {
+const observer = new MutationObserver(() => {
   pageContentchanged = true;
+});
+observer.observe(document.body, {
+  childList: true,
+  subtree: true,
 });
 setInterval(removeSponsoredAds, 200);
 console.log("amazon-sponsored-items-blocker loaded");


### PR DESCRIPTION
Since [the mutation events](https://developer.mozilla.org/en-US/docs/Web/API/MutationEvent) are deprecated already, replace them by standard [`MutationObserver`](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) as guidance. And also use ES2015 after the IE's EOL.

---

@Stefan-Code long time no see. I reopen the refinement PR.